### PR TITLE
Added SSL to GMP link in header file

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,5 +1,5 @@
 <meta charset="UTF-8">
-<link href="http://gmpg.org/xfn/11" rel="profile">
+<link href="https://gmpg.org/xfn/11" rel="profile">
 <head><title>{{ page.title }}</title></head>
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 


### PR DESCRIPTION
Not sure why but it suddenly wasn't secure and got flagged by Netlify as a warning against insecure content.